### PR TITLE
add forwarded allow ips to gunicorn

### DIFF
--- a/gunicorn_conf.py
+++ b/gunicorn_conf.py
@@ -21,6 +21,8 @@
 bind = ':8000'
 backlog = 2048
 
+forwarded_allow_ips = '*'
+
 #
 # Worker processes
 #


### PR DESCRIPTION
Adds line to allow swagger/frontend documentation pages to recognize `https` scheme and make ssl-enabled requests to API

fixes:

https://github.com/hackoregon/2019-transportation-systems-backend/issues/63

see:
http://docs.gunicorn.org/en/stable/settings.html#forwarded-allow-ips