### PR TITLE
Staging

### DIFF
--- a/gunicorn_conf.py
+++ b/gunicorn_conf.py
@@ -90,7 +90,7 @@ except ImportError:
     pass
 
 # worker_connections = 1000
-# timeout = 30
+timeout = 60
 # keepalive = 2
 
 #

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -17,3 +17,4 @@ gevent>=1.4.0,<2.0.0
 
 django-health-check>=3.10.2,<4.0.0
 psutil>=5.6.3,<6.0.0
+psycogreen


### PR DESCRIPTION
Fixes aysnc worker implementation
also sets worker timeout to 60 sec to allow for longer running api requests (perhaps will roll back to 30 at later point)